### PR TITLE
github.com/sirupsen/logrus -> github.com/Sirupsen/logrus

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 // Format is the type of log formatting options avaliable


### PR DESCRIPTION
For ease of vendoring go-runc in containerd.
(It had required both sirupsen/logrus and Sirupsen/logrus)
https://github.com/docker/containerd/pull/415/files#r95741905

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>