### PR TITLE
Add temp console socket creation

### DIFF
--- a/console.go
+++ b/console.go
@@ -4,7 +4,9 @@ package runc
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/crosbymichael/console"
@@ -28,10 +30,33 @@ func NewConsoleSocket(path string) (*Socket, error) {
 	}, nil
 }
 
+// NewTempConsoleSocket returns a temp console socket for use with a container
+// On Close(), the socket is deleted
+func NewTempConsoleSocket() (*Socket, error) {
+	dir, err := ioutil.TempDir("", "pty")
+	if err != nil {
+		return nil, err
+	}
+	abs, err := filepath.Abs(filepath.Join(dir, "pty.sock"))
+	if err != nil {
+		return nil, err
+	}
+	l, err := net.Listen("unix", abs)
+	if err != nil {
+		return nil, err
+	}
+	return &Socket{
+		l:     l,
+		rmdir: true,
+		path:  abs,
+	}, nil
+}
+
 // Socket is a unix socket that accepts the pty master created by runc
 type Socket struct {
-	path string
-	l    net.Listener
+	path  string
+	rmdir bool
+	l     net.Listener
 }
 
 // Path returns the path to the unix socket on disk
@@ -63,5 +88,11 @@ func (c *Socket) ReceiveMaster() (console.Console, error) {
 
 // Close closes the unix socket
 func (c *Socket) Close() error {
-	return c.l.Close()
+	err := c.l.Close()
+	if c.rmdir {
+		if rerr := os.RemoveAll(filepath.Dir(c.path)); err == nil {
+			err = rerr
+		}
+	}
+	return err
 }

--- a/console_test.go
+++ b/console_test.go
@@ -1,0 +1,20 @@
+package runc
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTempConsole(t *testing.T) {
+	c, err := NewTempConsoleSocket()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := c.Path()
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("path still exists")
+	}
+}


### PR DESCRIPTION
This adds the ability to create the console socket in the os temp dir so
that the path limit is not hit when common uses cases like docker using
/run with the containerd id overloading the socket creation call.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>